### PR TITLE
Fix for running the job manually from the Admin panel.

### DIFF
--- a/api/v3/Job/Partneremailgreeting.php
+++ b/api/v3/Job/Partneremailgreeting.php
@@ -29,6 +29,8 @@ function _civicrm_api3_job_Partneremailgreeting_spec(&$spec) {
  */
 function civicrm_api3_job_Partneremailgreeting($params) {
   try {
+    // Set max_execution_time to 30 mins to allow for large contact lists to process
+    ini_set('max_execution_time', '1800');
 
     // Get all active Partner and Spouse relationships, update email greeting for each contact in the relationship
 


### PR DESCRIPTION
When running the scheduled task via `System Settings -> Scheduled Jobs` via `Execute Now` the default script timeout of 300 seconds isn't long enough to complete the job with a large contact list.

This change extends the scripts capable runnning time to 1800 seconds.